### PR TITLE
Move validation code to validate.py, cleanup code style

### DIFF
--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -147,7 +147,8 @@ reserved_membernames = (
 )
 
 
-def is_valid_spydertype(type_name):
+# Todo - memoize
+def is_valid_spydertype(type_name, permit_array=False):
     """Tests if a string is a valid Spyder type"""
     if not type_name.replace("_", "x").isalnum():
         return False
@@ -158,28 +159,25 @@ def is_valid_spydertype(type_name):
     if len(type_name) > 1 and type_name == type_name.upper():
         return False
 
-    if type_name.endswith("Array") or type_name in reserved_types:
+    if permit_array:
+        array_depth = 0
+        while type_name.endswith("Array"):
+            type_name = type_name[:-len("Array")]
+            array_depth += 1
+
+        if array_depth > max_array_depth:
+            return False
+
+    elif type_name.endswith("Array"):
+        return False
+
+    if type_name in reserved_types:
         return False
 
     for ending in reserved_endings:
         if type_name.endswith(ending):
             return False
     return True
-
-
-def is_valid_spydertype2(type_name):
-    """Tests if a string is a valid Spyder type. Endings with Array are also allowed
-    """
-    array_depth = 0
-
-    while type_name.endswith("Array"):
-        type_name = type_name[:-len("Array")]
-        array_depth += 1
-
-    if array_depth > max_array_depth: # Why 3?
-        return False
-
-    return is_valid_spydertype(type_name)
 
 
 from . import manager, parse

--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -118,70 +118,10 @@ TODO:
 
 """
 
-max_array_depth = 2
-
-
-reserved_types = (
-  "Spyder",
-  "Type",
-  "Object",
-  "Delete",
-  "Include",
-  "None",
-  "True",
-  "False",
-)
-
-reserved_endings = (
-  "Error",
-  "Exit",
-  "Exception",
-)
-
-reserved_membernames = (
-  "type", "typename", "length", "name",
-  "convert", "cast", "validate",
-  "data", "str", "repr", "dict", "fromfile", "tofile",
-  "listen", "block", "unblock", "buttons", "form",
-  "invalid",
-)
-
-
-# Todo - memoize
-def is_valid_spydertype(type_name, permit_array=False):
-    """Tests if a string is a valid Spyder type"""
-    if not type_name.replace("_", "x").isalnum():
-        return False
-
-    if not type_name[0].isupper():
-        return False
-
-    if len(type_name) > 1 and type_name == type_name.upper():
-        return False
-
-    if permit_array:
-        array_depth = 0
-        while type_name.endswith("Array"):
-            type_name = type_name[:-len("Array")]
-            array_depth += 1
-
-        if array_depth > max_array_depth:
-            return False
-
-    elif type_name.endswith("Array"):
-        return False
-
-    if type_name in reserved_types:
-        return False
-
-    for ending in reserved_endings:
-        if type_name.endswith(ending):
-            return False
-    return True
-
+import sys
 
 from . import manager, parse
-import sys
+from .validate import is_valid_spydertype, reserved_endings, reserved_membernames, reserved_types
 
 
 def init():

--- a/spyder/__init__.py
+++ b/spyder/__init__.py
@@ -118,6 +118,9 @@ TODO:
 
 """
 
+max_array_depth = 2
+
+
 reserved_types = (
   "Spyder",
   "Type",
@@ -136,45 +139,52 @@ reserved_endings = (
 )
 
 reserved_membernames = (
-  "type","typename","length","name",
-  "convert","cast","validate",
-  "data","str","repr","dict","fromfile","tofile",
-  "listen","block","unblock","buttons","form",
+  "type", "typename", "length", "name",
+  "convert", "cast", "validate",
+  "data", "str", "repr", "dict", "fromfile", "tofile",
+  "listen", "block", "unblock", "buttons", "form",
   "invalid",
 )
 
-def is_valid_spydertype(s):
-    """
-    Tests if a string is a valid Spyder type
-    """
-    if s.replace("_", "x").isalnum() == False:
+
+def is_valid_spydertype(type_name):
+    """Tests if a string is a valid Spyder type"""
+    if not type_name.replace("_", "x").isalnum():
         return False
-    if s[0].isupper() == False:
+
+    if not type_name[0].isupper():
         return False
-    if len(s) > 1 and s == s.upper():
+
+    if len(type_name) > 1 and type_name == type_name.upper():
         return False
-    if s.endswith("Array") or s in reserved_types:
+
+    if type_name.endswith("Array") or type_name in reserved_types:
         return False
+
     for ending in reserved_endings:
-        if s.endswith(ending):
+        if type_name.endswith(ending):
             return False
     return True
 
-def is_valid_spydertype2(s):
+
+def is_valid_spydertype2(type_name):
+    """Tests if a string is a valid Spyder type. Endings with Array are also allowed
     """
-    Tests if a string is a valid Spyder type
-    endings with Array are also allowed
-    """
-    arraycount = 0
-    while s.endswith("Array"):
-        s = s[:-len("Array")]
-        arraycount += 1
-    if arraycount >= 3:
+    array_depth = 0
+
+    while type_name.endswith("Array"):
+        type_name = type_name[:-len("Array")]
+        array_depth += 1
+
+    if array_depth > max_array_depth: # Why 3?
         return False
-    return is_valid_spydertype(s)
+
+    return is_valid_spydertype(type_name)
+
 
 from . import manager, parse
 import sys
+
 
 def init():
     pass

--- a/spyder/parse/exceptions.py
+++ b/spyder/parse/exceptions.py
@@ -1,0 +1,2 @@
+class SpyderParseError(Exception):
+    """Generic spyder error"""

--- a/spyder/parse/macros/__init__.py
+++ b/spyder/parse/macros/__init__.py
@@ -1,8 +1,20 @@
+# Import macros
+from .optional import macro_optional
+from .bracket_length import macro_bracket_length
+from .enum import macro_enum
+
+
 _macros = []
+
+
 def register_macro(macro):
     _macros.append(macro)
+
 
 def get_macros():
     return list(_macros)
 
-from . import optarg, bracketlength, enum
+
+register_macro(macro_optional)
+register_macro(macro_bracket_length)
+register_macro(macro_enum)

--- a/spyder/parse/macros/bracket_length.py
+++ b/spyder/parse/macros/bracket_length.py
@@ -1,7 +1,5 @@
 # Copyright 2007-2016, Sjoerd de Vries
 
-from . import register_macro
-
 
 def macro_bracket_length(name, content):
     original_content = content
@@ -24,6 +22,3 @@ def macro_bracket_length(name, content):
     result += "\nform {\n  %s.length = %s\n  %s.form = \"hard\"\n}\n" % (attrib_name, length, attrib_name)
 
     return result
-
-
-register_macro(macro_bracket_length)

--- a/spyder/parse/macros/bracketlength.py
+++ b/spyder/parse/macros/bracketlength.py
@@ -2,19 +2,28 @@
 
 from . import register_macro
 
-def macro_bracketlength(name,content):
-    content0 = content
+
+def macro_bracketlength(name, content):
+    original_content = content
     default = ""
-    p = content0.find("=")
-    if p > -1:
-        content0 = content[:p].rstrip()
-        default = content[p:]
-    if not content0.endswith("]"): return
-    p = content0.rfind("[")
-    ret = name + " " + content0[:p] + default
-    l = content0[p+1:-1]
-    v = content0[:p]
-    ret += "\nvalidate {\n  assert %s is None or len(%s) == %s\n}\nform {\n  %s.length = %s\n  %s.form = \"hard\"\n}\n" % (v,v, l,v,l,v)
-    return ret
+    assign_index_start = original_content.find("=")
+
+    if assign_index_start > -1:
+        original_content = content[:assign_index_start].rstrip()
+        default = content[assign_index_start:]
+
+    if not original_content.endswith("]"):
+        return
+
+    assign_index_start = original_content.rfind("[")
+    result = name + " " + original_content[:assign_index_start] + default
+    length = original_content[assign_index_start+1:-1]
+    attrib_name = original_content[:assign_index_start]
+
+    result += "\nvalidate {\n  assert %s is None or len(%s) == %s\n}" % (attrib_name, attrib_name, length)
+    result += "\nform {\n  %s.length = %s\n  %s.form = \"hard\"\n}\n" % (attrib_name, length, attrib_name)
+
+    return result
+
 
 register_macro(macro_bracketlength)

--- a/spyder/parse/macros/bracketlength.py
+++ b/spyder/parse/macros/bracketlength.py
@@ -3,7 +3,7 @@
 from . import register_macro
 
 
-def macro_bracketlength(name, content):
+def macro_bracket_length(name, content):
     original_content = content
     default = ""
     assign_index_start = original_content.find("=")
@@ -26,4 +26,4 @@ def macro_bracketlength(name, content):
     return result
 
 
-register_macro(macro_bracketlength)
+register_macro(macro_bracket_length)

--- a/spyder/parse/macros/enum.py
+++ b/spyder/parse/macros/enum.py
@@ -1,7 +1,5 @@
 # Copyright 2007-2016, Sjoerd de Vries
 
-from . import register_macro
-
 
 def macro_enum(name, content):
     if not name.startswith("Enum"):
@@ -46,5 +44,3 @@ def macro_enum(name, content):
               (name, name, args_string, name, args_string[1:-1])
     return result
 
-
-register_macro(macro_enum)

--- a/spyder/parse/macros/enum.py
+++ b/spyder/parse/macros/enum.py
@@ -2,36 +2,49 @@
 
 from . import register_macro
 
-def macro_enum(name,content):
-    if not name.startswith("Enum"): return
-    brackdepth = 0
+
+def macro_enum(name, content):
+    if not name.startswith("Enum"):
+        return
+
+    bracket_depth = 0
     start = -1
     end = -1
-    for n in range(len(content)):
-        c = content[n]
-        if c.isalnum() or c == "_": continue
-        if c == "(":
-            if brackdepth == 0:
-                start = n
-            brackdepth += 1
-        elif c == ")":
-            if brackdepth == 0:
+
+    for i, char in enumerate(content):
+        if char.isalnum() or char == "_":
+            continue
+
+        if char == "(":
+            if bracket_depth == 0:
+                start = i
+
+            bracket_depth += 1
+
+        elif char == ")":
+            if bracket_depth == 0:
                 raise Exception("Compile error: invalid Enum member statement %s" % (name + " " + content))
-            brackdepth -= 1
-            if brackdepth == 0:
-                end = n
+
+            bracket_depth -= 1
+            if bracket_depth == 0:
+                end = i
                 break
-        elif brackdepth == 0:
+
+        elif bracket_depth == 0:
             raise Exception("Compile error: invalid Enum member statement %s" % (name + " " + content))
+
     if start == -1 or end == -1:
         raise Exception("Compile error: invalid Enum member statement %s" % (name + " " + content))
+
     name, enums = content[:start], content[start+1:end]
     if enums.find(",") == -1:
         enums += ","
-    arglist = "(" + enums + ")"
-    ret = "String " + name + content[end+1:]
-    ret += "\nvalidate {\n  if %s is not None: assert %s in %s\n}\nform {\n  %s.options = %s\n}\n" %  \
-     (name, name, arglist,name, arglist[1:-1])
-    return ret
+
+    args_string = "(" + enums + ")"
+    result = "String " + name + content[end+1:]
+    result += "\nvalidate {\n  if %s is not None: assert %s in %s\n}\nform {\n  %s.options = %s\n}\n" %  \
+              (name, name, args_string, name, args_string[1:-1])
+    return result
+
 
 register_macro(macro_enum)

--- a/spyder/parse/macros/optarg.py
+++ b/spyder/parse/macros/optarg.py
@@ -2,14 +2,18 @@
 
 from . import register_macro
 
+
 def macro_optarg(name, content):
-    if name[0] != "*": return
-    content0 = content
-    for n in range(len(content)):
-        if content[n].isalnum() == False and content[n] != "_":
-            content = content[:n]
+    if name[0] != "*":
+        return
+
+    original_content = content
+    for i, char in enumerate(content):
+        if char.isalnum() == False and char != "_":
+            content = char
             break
-    ret = name[1:] + " " + content0 + "\noptional {\n  " + content + "\n}\n"
-    return ret
+
+    return name[1:] + " " + original_content + "\noptional {\n  " + content + "\n}\n"
+
 
 register_macro(macro_optarg)

--- a/spyder/parse/macros/optional.py
+++ b/spyder/parse/macros/optional.py
@@ -1,9 +1,7 @@
 # Copyright 2007-2016, Sjoerd de Vries
 
-from . import register_macro
 
-
-def macro_optarg(name, content):
+def macro_optional(name, content):
     if name[0] != "*":
         return
 
@@ -14,6 +12,3 @@ def macro_optarg(name, content):
             break
 
     return name[1:] + " " + original_content + "\noptional {\n  " + content + "\n}\n"
-
-
-register_macro(macro_optarg)

--- a/spyder/parse/parse.py
+++ b/spyder/parse/parse.py
@@ -3,9 +3,10 @@
 import sys, re, os
 from lxml import etree
 from lxml.builder import E
-from .. import is_valid_spydertype
+
+from ..validate import is_valid_spydertype
 from .macros import get_macros
-from typedef import typedefparse
+from .typedef import typedef_parse
 
 #Regular expressions for:
 #    quotes ( "...", '...' )
@@ -24,6 +25,7 @@ TODO: replace them with rarely-used ASCII codes
 masksign_triplequote = "&"
 masksign_quote = "*"
 masksign_curly = "!"
+
 
 def parse(spytext):
     """
@@ -54,9 +56,8 @@ def parse(spytext):
         bases = []
         if len(blockheadwords) == 2:
             bases = [b.strip() for b in blockheadwords[1].split(",")]
-        ret[typename] = typedefparse(typename, bases, block)
+        ret[typename] = typedef_parse(typename, bases, block)
     return ret
-
 
 
 def divide_blocks(spytext):

--- a/spyder/parse/parse.py
+++ b/spyder/parse/parse.py
@@ -3,7 +3,7 @@
 import sys, re, os
 from lxml import etree
 from lxml.builder import E
-from .. import is_valid_spydertype, is_valid_spydertype2
+from .. import is_valid_spydertype
 from .macros import get_macros
 from typedef import typedefparse
 

--- a/spyder/parse/typedef.py
+++ b/spyder/parse/typedef.py
@@ -5,7 +5,6 @@ from ..validate import is_valid_spydertype
 
 def define_error(tree, block):
     from .parse import single_quote_match
-    currpos = 0
     matches = single_quote_match.finditer(block)
     node = E.errorblock()
     tree.append(node)
@@ -30,34 +29,34 @@ def typedef_block(tree, name, block):
         return
 
     elif name == "optional":
-        nodename = "optional"
+        node_name = "optional"
         block = "".join([l.strip() for l in block.splitlines()])
 
     elif name == "validate":
-        nodename = "validationblock"
+        node_name = "validationblock"
 
     elif name == "form":
-        nodename = "formblock"
+        node_name = "formblock"
 
     else:
         raise ValueError(name)
 
-    tree.append(getattr(E, nodename)(block))
+    tree.append(getattr(E, node_name)(block))
 
 
-def add_doc(last_member, docstring, newdoc):
+def add_doc(last_member, docstring, new_docstring):
     if last_member is None:
-        docstring.text += newdoc
+        docstring.text += new_docstring
 
     else:
         try:
-            mdoc = last_member.find("docstring")
+            element = last_member.find("docstring")
 
         except:
-            mdoc = E.docstring(newdoc)
-            last_member.append(mdoc)
+            element = E.docstring(new_docstring)
+            last_member.append(element)
 
-        mdoc.text += newdoc
+        element.text += new_docstring
 
 
 def typedef_parse(typename, bases, block):

--- a/spyder/parse/typedef.py
+++ b/spyder/parse/typedef.py
@@ -1,6 +1,6 @@
 from lxml import etree
 from lxml.builder import E
-from .. import is_valid_spydertype, is_valid_spydertype2
+from .. import is_valid_spydertype
 
 def define_error(tree, block):
   from .parse import quotematch
@@ -48,7 +48,7 @@ def typedefparse(typename, bases, block):
     if not is_valid_spydertype(typename):
         raise Exception("Invalid Spyder type definition: invalid type name: ''%s'" % typename)
     for base in bases:
-        if not is_valid_spydertype2(base):
+        if not is_valid_spydertype(base, permit_array=True):
             raise Exception("Invalid Spyder type definition: cannot inherit from non-Spyder type '%s'" % base)
     block_filtered = ""
 
@@ -154,7 +154,7 @@ def typedefparse(typename, bases, block):
                         raise Exception("Malformed member statement: %s" % l)
                     title = tsplit[0]
                     init = " ".join(tsplit[2:])
-                if not is_valid_spydertype2(name):
+                if not is_valid_spydertype(name, permit_array=True):
                     raise TypeError("Invalid member name '%s'" % name)
                 member = E.member(E.name(title),E.type(name))
                 if init is not None:

--- a/spyder/validate.py
+++ b/spyder/validate.py
@@ -1,0 +1,60 @@
+max_array_depth = 2
+
+
+reserved_types = (
+  "Spyder",
+  "Type",
+  "Object",
+  "Delete",
+  "Include",
+  "None",
+  "True",
+  "False",
+)
+
+reserved_endings = (
+  "Error",
+  "Exit",
+  "Exception",
+)
+
+reserved_membernames = (
+  "type", "typename", "length", "name",
+  "convert", "cast", "validate",
+  "data", "str", "repr", "dict", "fromfile", "tofile",
+  "listen", "block", "unblock", "buttons", "form",
+  "invalid",
+)
+
+
+# Todo - memoize
+def is_valid_spydertype(type_name, permit_array=False):
+    """Tests if a string is a valid Spyder type"""
+    if not type_name.replace("_", "x").isalnum():
+        return False
+
+    if not type_name[0].isupper():
+        return False
+
+    if len(type_name) > 1 and type_name == type_name.upper():
+        return False
+
+    if permit_array:
+        array_depth = 0
+        while type_name.endswith("Array"):
+            type_name = type_name[:-len("Array")]
+            array_depth += 1
+
+        if array_depth > max_array_depth:
+            return False
+
+    elif type_name.endswith("Array"):
+        return False
+
+    if type_name in reserved_types:
+        return False
+
+    for ending in reserved_endings:
+        if type_name.endswith(ending):
+            return False
+    return True


### PR DESCRIPTION
Some small PEP8 friendly changes, as well as improving readability by naming of variables.
Moved some parsing code into function (needs checking, noted with TODO)

Further changes should be made if we target Py2.7+ (str.format), and if only py3, could consider type info (def func(x:str, )). Py 3.5 has detailed type annotations, but only 3.5